### PR TITLE
docs: examples: multiline: new regex-001 example

### DIFF
--- a/documentation/examples/multiline/regex-001/fluent-bit.conf
+++ b/documentation/examples/multiline/regex-001/fluent-bit.conf
@@ -1,0 +1,14 @@
+[SERVICE]
+    flush        1
+    log_level    info
+    parsers_file parsers_multiline.conf
+
+[INPUT]
+    name             tail
+    path             test.log
+    read_from_head   true
+    multiline.parser multiline-regex-test
+
+[OUTPUT]
+    name             stdout
+    match            *

--- a/documentation/examples/multiline/regex-001/parsers_multiline.conf
+++ b/documentation/examples/multiline/regex-001/parsers_multiline.conf
@@ -1,0 +1,16 @@
+[MULTILINE_PARSER]
+    name          multiline-regex-test
+    type          regex
+    flush_timeout 1000
+    # Regex rules for multiline parsing
+    # ---------------------------------
+    #
+    # configuration hints:
+    #
+    #  - first state always has the name: start_state
+    #  - every field in the rule must be inside double quotes
+    #
+    # rules   |   state name   | regex pattern                   | next state name
+    # --------|----------------|--------------------------------------------------
+    rule         "start_state"   "/(Dec \d+ \d+\:\d+\:\d+)(.*)/"  "cont"
+    rule         "cont"          "/^\s+at.*/"                     "cont"

--- a/documentation/examples/multiline/regex-001/test.log
+++ b/documentation/examples/multiline/regex-001/test.log
@@ -1,0 +1,9 @@
+single line...
+Dec 14 06:41:08 Exception in thread "main" java.lang.RuntimeException: Something has gone wrong, aborting!
+    at com.myproject.module.MyProject.badMethod(MyProject.java:22)
+    at com.myproject.module.MyProject.oneMoreMethod(MyProject.java:18)
+    at com.myproject.module.MyProject.anotherMethod(MyProject.java:14)
+    at com.myproject.module.MyProject.someMethod(MyProject.java:10)
+    at com.myproject.module.MyProject.main(MyProject.java:6)
+another line...
+


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <edsiper@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
