### PR TITLE
out_prometheus_exporter: support multiple metrics

### DIFF
--- a/plugins/out_prometheus_exporter/prom.h
+++ b/plugins/out_prometheus_exporter/prom.h
@@ -22,6 +22,7 @@
 #define FLB_PROMETHEUS_EXPORTER_H
 
 #include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_hash.h>
 
 /* Plugin context */
 struct prom_exporter {
@@ -30,6 +31,9 @@ struct prom_exporter {
     /* networking */
     flb_sds_t listen;
     flb_sds_t tcp_port;
+
+    /* hash table for metrics reported */
+    struct flb_hash *ht_metrics;
 
     /* config reader for 'add_label' */
     struct mk_list *add_labels;


### PR DESCRIPTION
Previous implementation allowed to publish only one source of metrics. This
patch extends the functionality allowing to have multiple metrics from
different sources without generating collisions.

Now different metrics are concatenated.

Signed-off-by: Eduardo Silva <edsiper@gmail.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
