### PR TITLE
http_client: warn when flb_http_do() fails due to malformed data

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -1216,6 +1216,9 @@ int flb_http_do(struct flb_http_client *c, size_t *bytes)
 
             ret = process_data(c);
             if (ret == FLB_HTTP_ERROR) {
+                flb_warn("[http_client] malformed HTTP response from %s:%i on "
+                         "connection #%i", c->u_conn->u->tcp_host,
+                         c->u_conn->u->tcp_port, c->u_conn->fd);
                 return -1;
             }
             else if (ret == FLB_HTTP_OK) {


### PR DESCRIPTION
Most consumers of flb_http_do() do not log much information when it
fails (e.g. "[warn] http_do=-1"), resulting in difficult debugging.

This commit simply adds a warning when the HTTP response could not be
processed correctly (i.e. it is malformed in some way).

This should help disambiguate errors in flb_http_do().

Signed-off-by: Aaron Jacobs <aaron.jacobs@crescendotechnology.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
