### PR TITLE
http_client: log allocation failures for request headers

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -1128,6 +1128,7 @@ int flb_http_do(struct flb_http_client *c, size_t *bytes)
         new_size = c->header_size + 2;
         tmp = flb_realloc(c->header_buf, new_size);
         if (!tmp) {
+            flb_errno();
             return -1;
         }
         c->header_buf  = tmp;


### PR DESCRIPTION
Calls to flb_realloc() normally log allocation failures with
flb_errno(). This commit adds this missing logging.

This should help disambiguate errors in flb_http_do() that are due to
memory issues as opposed to HTTP-level issues.

Signed-off-by: Aaron Jacobs <aaron.jacobs@crescendotechnology.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
